### PR TITLE
Add support for tasks with tags

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -111,8 +111,21 @@ pub fn info(task: &task::Task) {
         );
     }
 
+    if !task.tags.is_empty() {
+        print!(
+            "{}Tags:{} ",
+            color::Fg(color::Blue),
+            color::Fg(color::Reset),
+        );
+        print!("{}", task.tags[0]);
+        for tag in &task.tags[1..] {
+            print!(", {}", tag);
+        }
+        println!();
+    }
+
     let creation_time = format!(
-        "{color}Created:{reset} {color}{}{reset} at {color}{}{reset}",
+        "{color}Created:{reset}{} at {}",
         task.creation_time.format("%v"),
         task.creation_time.format("%I%P:%Mm"),
         color = color::Fg(color::Yellow),

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,14 @@ fn main() {
                         .empty_values(false)
                         .possible_values(&["low", "medium", "high"])
                         .help("Priority of the task"),
+                ).arg(
+                    Arg::with_name("tag")
+                        .short("t")
+                        .long("tag")
+                        .takes_value(true)
+                        .empty_values(false)
+                        .multiple(true)
+                        .help("tag to be assigned to the task"),
                 ),
         ).subcommand(
             SubCommand::with_name("del")
@@ -137,6 +145,9 @@ fn main() {
                 _ => unreachable!(),
             };
             task.priority = Some(priority);
+        }
+        if let Some(tags) = matches.values_of("tag") {
+            task.tags = tags.map(|t| t.to_string()).collect();
         }
         tsk_data.add_task(task);
         return;

--- a/src/task.rs
+++ b/src/task.rs
@@ -14,6 +14,7 @@ pub struct Task {
     pub priority: Option<Priority>,
     pub creation_time: DateTime<Local>,
     pub comp_time: Option<DateTime<Local>>,
+    pub tags: Vec<String>,
 }
 
 impl Task {
@@ -24,6 +25,7 @@ impl Task {
             priority: None,
             creation_time: Local::now(),
             comp_time: None,
+            tags: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
This PR adds support for tags which can be added at task creation and are viewable with the `info` sub-command.